### PR TITLE
Potential fix for code scanning alert no. 27: Creating biased random numbers from a cryptographically secure source

### DIFF
--- a/apps/server/src/utils/tokens.ts
+++ b/apps/server/src/utils/tokens.ts
@@ -56,7 +56,18 @@ export function isExpired(date: Date): boolean {
  * The hash is stored server-side; the plaintext code is sent via email.
  */
 export function generateOtp(): { code: string; hash: string } {
-  const num = randomBytes(4).readUInt32BE(0) % 1_000_000;
+  const max = 0xffffffff; // Maximum value for a 32-bit unsigned integer
+  const limit = max - (max % 1_000_000);
+
+  let num: number;
+  while (true) {
+    const candidate = randomBytes(4).readUInt32BE(0);
+    if (candidate <= limit) {
+      num = candidate % 1_000_000;
+      break;
+    }
+  }
+
   const code = num.toString().padStart(6, '0');
   return { code, hash: hashToken(code) };
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Akaal-Creatives/LibreDiary/security/code-scanning/27](https://github.com/Akaal-Creatives/LibreDiary/security/code-scanning/27)

In general, the problem is fixed by avoiding a plain modulo operation on a cryptographically secure random integer when mapping it into a smaller range. Instead, use rejection sampling: generate random values in a larger space, discard any values that would cause bias, and only take values from a range that is an exact multiple of the desired modulus. Alternatively, use a well‑tested library that already does this correctly.

For this specific code, the best fix with minimal functional change is to implement rejection sampling around the existing `randomBytes(4).readUInt32BE(0)` call. We want a uniform integer in `[0, 999_999]`. Let `MOD = 1_000_000` and `MAX = 2**32`. Compute `limit = MAX - (MAX % MOD)` (i.e., the largest multiple of `MOD` less than `2**32`). Draw 32‑bit values until one is `< limit`, then return `value % MOD`. This preserves uniformity over the 6‑digit space while still returning a string padded to 6 digits as before. No new imports are needed; we already import `randomBytes` and will keep using it. The only code change is to replace the biased line 59 with a loop implementing rejection sampling; the rest of `generateOtp` and the file remains unchanged.

Concretely:
- In `apps/server/src/utils/tokens.ts`, in `generateOtp`, replace the line computing `num` with a small loop that:
  - Computes `const max = 0xffffffff;`
  - Computes `const limit = max - (max % 1_000_000);`
  - Draws 4 random bytes, interprets as `candidate`, and repeats if `candidate > limit`.
  - Sets `num = candidate % 1_000_000`.
The rest of the function (`code`, `hash`) stays the same, so there is no external API change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
